### PR TITLE
fix: fix double import for openems.__main__

### DIFF
--- a/openems/__init__.py
+++ b/openems/__init__.py
@@ -1,3 +1,2 @@
 """OpenEMS."""
-from . import __main__  # noqa
 from . import api  # noqa


### PR DESCRIPTION
previous code has double import and it show below error
```
<frozen runpy>:128: RuntimeWarning: 'openems.__main__' found in
sys.modules after import of package 'openems', but prior to
execution of 'openems.__main__'; this may result in unpredictable
behaviour
```