### PR TITLE
Fix typos and variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
           },
           "channels": {
 
-### fetcing meter value
+### fetching meter value
 
     $ python -m openems ... get-meter-list edge0
     meter0
@@ -56,7 +56,7 @@
     2024-01-01T14:50:00Z,5838000.0
     2024-01-01T14:55:00Z,5838100.0
 
-### fetcing pvinverter value
+### fetching pvinverter value
 
     $ python -m openems ... get-pvinverter-list edge0
     pvInverter1

--- a/openems/__main__.py
+++ b/openems/__main__.py
@@ -55,9 +55,9 @@ def get_meter_list(ctx, edge_id):
 @click.argument('edge-id')
 def get_pvinverter_list(ctx, edge_id):
     """Get OpenEMS PVInverter List."""
-    meters = ctx.obj['client'].get_pvinverter_list(edge_id)
+    pvinverters = ctx.obj['client'].get_pvinverter_list(edge_id)
 
-    for (k, _) in meters.items():
+    for (k, _) in pvinverters.items():
         click.echo(click.style(k, fg='green'))
 
 

--- a/openems/api.py
+++ b/openems/api.py
@@ -139,13 +139,13 @@ class OpenEMSAPIClient():
         )
 
     def get_meter_list(self, edge_id):
-        """Extract meter list form edge config."""
+        """Extract meter list from edge config."""
         edge_config = self.get_edge_config(edge_id)
         components = edge_config['components']
         return dict([(k, v) for (k, v) in components.items() if v['factoryId'].split('.')[0] == 'Meter'])
 
     def get_pvinverter_list(self, edge_id):
-        """Extract pvinverter list form edge config."""
+        """Extract pvinverter list from edge config."""
         edge_config = self.get_edge_config(edge_id)
         components = edge_config['components']
         return dict([(k, v) for (k, v) in components.items() if v['factoryId'].split('.')[0] == 'PVInverter'])


### PR DESCRIPTION
## Summary
- fix typos in README usage section
- fix docstrings referencing list extraction
- rename variable used in PV inverter CLI command

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'jsonrpc_base')*