### PR TITLE
fix: pytestの出力を色付けする

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
   pytest-randomly
 
 commands =
-  pytest -v --durations=0 --cov={envsitepackagesdir}/{[testenv]package_name} --cov-report=xml --cov-fail-under=0 {posargs}
+  pytest -v --color=yes --durations=0 --cov={envsitepackagesdir}/{[testenv]package_name} --cov-report=xml --cov-fail-under=0 {posargs}
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
https://github.com/girasolenergy/SWTeam/issues/32