### PR TITLE
feat: fix  exisiting event loop problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - {'toxenv': 'py38', 'container': 'python:3.8'}
-          - {'toxenv': 'py39', 'container': 'python:3.9'}
           - {'toxenv': 'py310', 'container': 'python:3.10'}
           - {'toxenv': 'py311', 'container': 'python:3.11'}
           - {'toxenv': 'py312', 'container': 'python:3.12'}

--- a/openems/__main__.py
+++ b/openems/__main__.py
@@ -90,9 +90,10 @@ def update_component_config(ctx, edge_id, component_id, name, value):
 @click.argument('channel')
 @click.argument('start', type=click.DateTime(['%Y-%m-%d']))
 @click.argument('end', type=click.DateTime(['%Y-%m-%d']))
-def get_channel_data(ctx, edge_id, channel, start, end):
+@click.argument('resolution-sec', type=int)
+def get_channel_data(ctx, edge_id, channel, start, end, resolution_sec):
     """Get OpenEMS Channel Data."""
-    df = ctx.obj['client'].query_historic_timeseries_data(edge_id, start.date(), end.date(), [channel])
+    df = ctx.obj['client'].query_historic_timeseries_data(edge_id, start.date(), end.date(), [channel], resolution_sec)
 
     click.echo(click.style(df.to_csv(), fg='green'))
 

--- a/openems/api.py
+++ b/openems/api.py
@@ -2,7 +2,9 @@
 import uuid
 
 import jsonrpc_base
+
 from jsonrpc_websocket import Server
+
 import pandas as pd
 
 from . import exceptions

--- a/openems/api.py
+++ b/openems/api.py
@@ -1,15 +1,12 @@
 """OpenEMS API."""
-import asyncio
 import uuid
 
 import jsonrpc_base
-
 from jsonrpc_websocket import Server
-
 import pandas as pd
 
-from .utils.bridge import ASGIRefBridge
 from . import exceptions
+from .utils.bridge import ASGIRefBridge
 
 
 class OpenEMSAPIClient():

--- a/openems/utils/bridge.py
+++ b/openems/utils/bridge.py
@@ -1,0 +1,34 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable
+from asgiref.sync import async_to_sync
+import threading
+
+class ASGIRefBridge:
+    def __init__(self, max_workers: int = 1) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self.isinparentloop = self.isinloop()
+
+        if not self.isinparentloop:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+
+    def run(self, async_fn: Callable[..., Any], /, *args, timeout: float | None = None, **kwargs) -> Any:
+        if self.isinparentloop:
+            fut = self._executor.submit(lambda: async_to_sync(async_fn)(*args, **kwargs))
+            return fut.result(timeout=timeout)
+        else:
+            return self.loop.run_until_complete(async_fn(*args, **kwargs))
+
+    def isinloop(self):
+        try:
+            loop = asyncio.get_running_loop()
+            if loop.is_running():
+                return True
+            else:
+                return False
+        except RuntimeError:
+            return False
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=True)

--- a/openems/utils/bridge.py
+++ b/openems/utils/bridge.py
@@ -1,7 +1,8 @@
 """ASGI Reference Bridge utilities."""
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 from asgiref.sync import async_to_sync
 
@@ -11,7 +12,7 @@ class ASGIRefBridge:
 
     def __init__(self, max_workers: int = 1) -> None:
         """Initialize the ASGI Reference Bridge.
-        
+
         Args:
             max_workers: Maximum number of worker threads.
         """
@@ -24,13 +25,13 @@ class ASGIRefBridge:
 
     def run(self, async_fn: Callable[..., Any], /, *args, timeout: float | None = None, **kwargs) -> Any:
         """Run an async function in the appropriate context.
-        
+
         Args:
             async_fn: The async function to run.
             *args: Positional arguments for the function.
             timeout: Timeout for execution.
             **kwargs: Keyword arguments for the function.
-            
+
         Returns:
             The result of the async function.
         """
@@ -42,7 +43,7 @@ class ASGIRefBridge:
 
     def isinloop(self):
         """Check if currently running in an event loop.
-        
+
         Returns:
             True if in an active event loop, False otherwise.
         """

--- a/openems/utils/bridge.py
+++ b/openems/utils/bridge.py
@@ -1,11 +1,20 @@
+"""ASGI Reference Bridge utilities."""
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
+
 from asgiref.sync import async_to_sync
-import threading
+
 
 class ASGIRefBridge:
+    """Bridge to handle async operations in sync context."""
+
     def __init__(self, max_workers: int = 1) -> None:
+        """Initialize the ASGI Reference Bridge.
+        
+        Args:
+            max_workers: Maximum number of worker threads.
+        """
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self.isinparentloop = self.isinloop()
 
@@ -14,6 +23,17 @@ class ASGIRefBridge:
             asyncio.set_event_loop(self.loop)
 
     def run(self, async_fn: Callable[..., Any], /, *args, timeout: float | None = None, **kwargs) -> Any:
+        """Run an async function in the appropriate context.
+        
+        Args:
+            async_fn: The async function to run.
+            *args: Positional arguments for the function.
+            timeout: Timeout for execution.
+            **kwargs: Keyword arguments for the function.
+            
+        Returns:
+            The result of the async function.
+        """
         if self.isinparentloop:
             fut = self._executor.submit(lambda: async_to_sync(async_fn)(*args, **kwargs))
             return fut.result(timeout=timeout)
@@ -21,6 +41,11 @@ class ASGIRefBridge:
             return self.loop.run_until_complete(async_fn(*args, **kwargs))
 
     def isinloop(self):
+        """Check if currently running in an event loop.
+        
+        Returns:
+            True if in an active event loop, False otherwise.
+        """
         try:
             loop = asyncio.get_running_loop()
             if loop.is_running():
@@ -31,4 +56,5 @@ class ASGIRefBridge:
             return False
 
     def shutdown(self) -> None:
+        """Shutdown the thread pool executor."""
         self._executor.shutdown(wait=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     'click<8.2,>=8.1',
     'jsonrpc-websocket>=3.1,<3.2',
     'pandas>=2.0,<2.4',
+    'asgiref>=3.9,<3.10',
 ]
 dynamic = ['version', 'readme']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'click<8.2,>=8.1',
     'jsonrpc-websocket>=3.1,<3.2',
     'pandas>=2.0,<2.4',
-    'asgiref>=3.9,<3.10',
+    'asgiref>=3.8,<3.10',
 ]
 dynamic = ['version', 'readme']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'click<8.2,>=8.1',
     'jsonrpc-websocket>=3.1,<3.2',
     'pandas>=2.0,<2.4',
-    'asgiref>=3.8,<3.10',
+    'asgiref>=3.9,<3.10',
 ]
 dynamic = ['version', 'readme']
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, mypy, bandit, pip-audit, py37, py38, py39, py310, py311, py312, py313
+envlist = flake8, mypy, bandit, pip-audit, py310, py311, py312, py313
 
 [testenv]
 package_name = openems


### PR DESCRIPTION
The current implementation creates a new event loop even when one already exists.
But asyncio does not allow more than one event loop in the same thread, so this fails in those cases.
For example, FastAPI and Jupyter Notebook already run an event loop, so they cannot work with pyopenems as-is.

This PR adds a simple mechanism to handle the event loop.

It switches behavior based on whether an event loop is already running:

- No running loop: create a new event loop and run the task there.
- Loop already running: start a new thread and run the task in that thread.